### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ os:
   - linux
   - osx
 
+arch:
+  - amd64
+  - ppc64le
+
+matrix:
+   exclude:
+       - os: osx
+         arch: ppc64le
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/flvmeta/builds/189667304 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!