### PR TITLE
bugfix: fix info->last_timestamp under overflow in compute_metadata

### DIFF
--- a/src/info.h
+++ b/src/info.h
@@ -75,7 +75,7 @@ extern "C" {
 
 int get_flv_info(flv_stream * flv_in, flv_info * info, const flvmeta_opts * opts);
 
-void compute_metadata(flv_info * info, flv_metadata * meta, const flvmeta_opts * opts);
+int compute_metadata(flv_info * info, flv_metadata * meta, const flvmeta_opts * opts);
 
 void compute_current_metadata(flv_info * info, flv_metadata * meta);
 

--- a/src/update.c
+++ b/src/update.c
@@ -276,7 +276,12 @@ int update_metadata(const flvmeta_opts * opts) {
         return res;
     }
 
-    compute_metadata(&info, &meta, opts);
+    res = compute_metadata(&info, &meta, opts);
+    if (res != OK) {
+        flv_close(flv_in);
+        amf_data_free(info.keyframes);
+        return res;
+    }
 
     /*
         open output file


### PR DESCRIPTION
Hi,

This PR fixes an unsigned integer underflow in duration computation (src/info.c).

How to reproduce:

1. Configure and build with UBSan + ASan

mkdir -p build && cd build
CC=clang cmake .. 
-DCMAKE_BUILD_TYPE=Debug 
-DCMAKE_C_FLAGS="-O0 -g -fno-omit-frame-pointer -fsanitize=undefined,address,unsigned-integer-overflow"
cmake --build . -j

2. Run:

./src/flvmeta input.bin "" "" input.bin
Please unzip this testcase here: [input.bin.zip](https://github.com/user-attachments/files/25344284/input.bin.zip)

* reports:
/Users/xmoe/Downloads/flvmeta2/src/info.c:572:42: runtime error: unsigned integer overflow: 0 - 8 cannot be represented in type 'uint32' (aka 'unsigned int')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/xxx/Downloads/flvmeta2/src/info.c:572:42

3. Fix

* Validate last_timestamp >= base_timestamp before subtraction.
* Compute with uint64_t temporaries and return FLV_ERROR_INVALID_METADATA on invalid duration.

Affected versions

* master (latest commit: b54861c)
* release 1.2.2

